### PR TITLE
Some small fixes to inlining and linking

### DIFF
--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -2913,7 +2913,7 @@ static bool addSanitizerRuntimes(const ToolChain &TC, const ArgList &Args,
     CmdArgs.push_back("-export-dynamic");
 
   if (TC.getSanitizerArgs().needsCrunchRt())
-    CmdArgs.push_back("-lcrunch_preload");
+    CmdArgs.push_back("-lcrunch_stubs");
 
   return !StaticRuntimes.empty();
 }


### PR DESCRIPTION
Previously, the clang instrumentation wasn't able to inline libcrunch's helpers (in libcrunch_cil_inlines.h). At first I thought this was because they'd been discarded by codegen time, but actually it's mainly because self-instrumentation had made the helpers recursive and therefore non-inlineable. These changes fix this problem and also avoid linking against the preload libcrunch -- the stubs one is the right choice, in order that checking remains optional.